### PR TITLE
Add samples kwarg and run docs example for 10000 samples

### DIFF
--- a/docs/src/tutorials/sensitivity_analysis.md
+++ b/docs/src/tutorials/sensitivity_analysis.md
@@ -45,7 +45,7 @@ Thus for example, let's calculate the sensitivity of `y(100)` over the parameter
 
 ```@example sensitivity
 pbounds = [ρ => [0.0, 20.0], β => [0.0, 100.0]]
-sensres = get_sensitivity(prob, 100.0, y, pbounds)
+sensres = get_sensitivity(prob, 100.0, y, pbounds; samples = 10000)
 ```
 
 The output shows values of `first_order`, `second_order` and `total_order` sensitivities. These are quantities that define the


### PR DESCRIPTION
Looks like the summation mismatch was only because of non-convergence. 

Now with 50k samples
```
julia> sensres[:ρ_first_order] + sensres[:ρ_β_second_order], sensres[:ρ_total_order]
(0.9509424921787797, 0.9594158904145137)

julia> sensres[:β_first_order] + sensres[:ρ_β_second_order], sensres[:β_total_order]
(0.9136216916167716, 0.8971416879820884)
```