### PR TITLE
Expose solve kws to datafit functions. 

### DIFF
--- a/test/ensemble.jl
+++ b/test/ensemble.jl
@@ -56,9 +56,9 @@ sol = solve(enprob; saveat = 1);
 
 weights = [0.2, 0.5, 0.3]
 
-fullS = vec(sum(stack(weights .* sol[:,S]),dims=2))
-fullI = vec(sum(stack(weights .* sol[:,I]),dims=2))
-fullR = vec(sum(stack(weights .* sol[:,R]),dims=2))
+fullS = vec(sum(stack(weights .* sol[S,:]),dims=2))
+fullI = vec(sum(stack(weights .* sol[I,:]),dims=2))
+fullR = vec(sum(stack(weights .* sol[R,:]),dims=2))
 
 t_train = 0:14
 data_train = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ const GROUP = get(ENV, "GROUP", "All")
         VERSION >= v"1.9" && @time @safetestset "Ensemble Tests" include("ensemble.jl")
         @time @safetestset "Threshold Tests" include("threshold.jl")
         @time @safetestset "Example Tests" include("examples.jl")
-    elseif GROUP == "All" || GROUP == "Datafit"
+    if GROUP == "All" || GROUP == "Datafit"
         @time @safetestset "Datafit Tests" include("datafit.jl")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,8 @@ const GROUP = get(ENV, "GROUP", "All")
         VERSION >= v"1.9" && @time @safetestset "Ensemble Tests" include("ensemble.jl")
         @time @safetestset "Threshold Tests" include("threshold.jl")
         @time @safetestset "Example Tests" include("examples.jl")
+    end
+    
     if GROUP == "All" || GROUP == "Datafit"
         @time @safetestset "Datafit Tests" include("datafit.jl")
     end


### PR DESCRIPTION
Users of `datafit` can pass keyword args to the solver for the OptimizationProblem. Standard l2loss function returns the solution along with the total loss so that callbacks to the solver can use the solution. 