### PR TITLE
Test Changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ SafeTestsets = "0.1"
 SciMLBase = "2.32.1"
 SciMLExpectations = "2"
 Test = "1"
-Turing = "0.30"
+Turing = "0.30,0.33"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ SafeTestsets = "0.1"
 SciMLBase = "2.32.1"
 SciMLExpectations = "2"
 Test = "1"
-Turing = "0.30,0.33"
+Turing = "0.33"
 julia = "1.10"
 
 [extras]

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,8 +1,8 @@
 using EasyModelAnalysis, Test
+using ModelingToolkit: t_nounits as t, D_nounits as D
 
-@parameters t σ ρ β
+@parameters σ ρ β
 @variables x(t) y(t) z(t)
-D = Differential(t)
 
 eqs = [D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,

--- a/test/datafit.jl
+++ b/test/datafit.jl
@@ -1,8 +1,8 @@
 using EasyModelAnalysis, Test
+using ModelingToolkit: t_nounits as t, D_nounits as D
 
-@parameters t σ ρ β
+@parameters σ ρ β
 @variables x(t) y(t) z(t)
-D = Differential(t)
 
 eqs = [D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
@@ -86,7 +86,7 @@ tsave = collect(10.0:10.0:100.0)
 sol_data = solve(prob, saveat = tsave)
 data = [x => sol_data[x], z => sol_data[z]]
 p_prior = [σ => Normal(26.8, 0.1), β => Normal(2.7, 0.1)]
-p_posterior = @time bayesian_datafit(prob, p_prior, tsave, data, niter = 3000)
+p_posterior = @time bayesian_datafit(prob, p_prior, tsave, data, niter = 40)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))
 
 tsave1 = collect(10.0:10.0:100.0)
@@ -95,5 +95,5 @@ tsave2 = collect(10.0:13.5:100.0)
 sol_data2 = solve(prob, saveat = tsave2)
 data_with_t = [x => (tsave1, sol_data1[x]), z => (tsave2, sol_data2[z])]
 
-p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 3000)
+p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 40)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))

--- a/test/datafit.jl
+++ b/test/datafit.jl
@@ -4,7 +4,7 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 @parameters σ ρ β
 @variables x(t) y(t) z(t)
 
-eqs = [D(D(x)) ~ σ * (y - x),
+eqs = [D(x) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
     D(z) ~ x * y - β * z]
 
@@ -23,7 +23,7 @@ tspan = (0.0, 100.0)
 prob = ODEProblem(sys, u0, tspan, p, jac = true)
 sol = solve(prob)
 
-tsave = [1.0, 2.0, 3.0]
+tsave = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
 sol_data = solve(prob, saveat = tsave)
 data = [x => sol_data[x], z => sol_data[z]]
 psub_ini = [σ => 27.0, β => 3.0]
@@ -32,7 +32,7 @@ pvals_fit = getfield.(fit, :second)
 pvals = getfield.(p, :second)[[1, 3]]
 @test isapprox(pvals, pvals_fit, atol = 1e-4, rtol = 1e-4)
 
-tsave1 = [1.0, 2.0, 3.0]
+tsave1 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
 sol_data1 = solve(prob, saveat = tsave1)
 tsave2 = [0.5, 1.5, 2.5, 3.5]
 sol_data2 = solve(prob, saveat = tsave2)
@@ -48,7 +48,7 @@ prob3 = remake(prob, p = psub_ini)
 scores = model_forecast_score([prob, prob2, prob3], tsave, data)
 @test scores[1] == 0
 @test scores[2] < 2e-3
-@test scores[3] > 10
+@test scores[3] > 2
 
 psub_ini = [σ => [27.0, 29.0], β => [2.0, 3.0]]
 fit = global_datafit(prob, psub_ini, tsave, data)
@@ -62,7 +62,7 @@ pvals = getfield.(p, :second)[[1, 3]]
 @test isapprox(pvals, pvals_fit, atol = 1e-4, rtol = 1e-4)
 
 @variables x_2(t)
-eqs_obs = [D(D(x)) ~ σ * (y - x),
+eqs_obs = [D(x) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
     D(z) ~ x * y - β * z,
     x_2 ~ 2 * x]

--- a/test/datafit.jl
+++ b/test/datafit.jl
@@ -4,16 +4,16 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 @parameters α β γ δ
 @variables x(t) y(t)
 
-eqs = [D(x) ~ α*x - β*x*y,
-    D(y) ~ -γ*y + δ*x*y]
+eqs = [D(x) ~ α * x - β * x * y,
+    D(y) ~ -γ * y + δ * x * y]
 
 @mtkbuild sys = ODESystem(eqs, t)
 
 u0 = [x => 1.0,
     y => 1.0]
 
-p = [α => 2/3,
-    β => 4/3,
+p = [α => 2 / 3,
+    β => 4 / 3,
     γ => 1,
     δ => 1]
 
@@ -51,7 +51,6 @@ scores = model_forecast_score([prob, prob2, prob3], tsave, data)
 @test scores[2] < 2e-3
 @test scores[3] > 2
 
-
 psub_ini = [
     α => [0.5, 0.9],
     β => [0.9, 1.5],
@@ -73,7 +72,7 @@ pvals = getfield.(p, :second)
 
 eqs_obs = [D(x) ~ α * x - β * x * y,
     D(y) ~ -γ * y + δ * x * y,
-    x_2 ~ 2*x]
+    x_2 ~ 2 * x]
 
 @mtkbuild sys_obs = ODESystem(eqs_obs, t)
 
@@ -93,8 +92,8 @@ tsave = collect(1.0:1.0:10.0)
 sol_data = solve(prob, saveat = tsave)
 data = [x => sol_data[x], y => sol_data[y]]
 
-
-p_prior = [α => Normal(2/3, 0.1), β => Normal(4/3,0.1), γ => Normal(1, 0.1), δ => Normal(1, 0.1)]
+p_prior = [α => Normal(2 / 3, 0.1), β => Normal(4 / 3, 0.1),
+    γ => Normal(1, 0.1), δ => Normal(1, 0.1)]
 p_posterior = @time bayesian_datafit(prob, p_prior, tsave, data, niter = 3000)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))
 

--- a/test/datafit.jl
+++ b/test/datafit.jl
@@ -95,5 +95,5 @@ tsave2 = collect(10.0:13.5:100.0)
 sol_data2 = solve(prob, saveat = tsave2)
 data_with_t = [x => (tsave1, sol_data1[x]), z => (tsave2, sol_data2[z])]
 
-p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 3000)
+p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 5000)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))

--- a/test/datafit.jl
+++ b/test/datafit.jl
@@ -1,46 +1,47 @@
 using EasyModelAnalysis, Test
 using ModelingToolkit: t_nounits as t, D_nounits as D
 
-@parameters σ ρ β
-@variables x(t) y(t) z(t)
+@parameters α β γ δ
+@variables x(t) y(t)
 
-eqs = [D(x) ~ σ * (y - x),
-    D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z]
+eqs = [D(x) ~ α*x - β*x*y,
+    D(y) ~ -γ*y + δ*x*y]
 
 @mtkbuild sys = ODESystem(eqs, t)
 
-u0 = [D(x) => 2.0,
-    x => 1.0,
-    y => 0.0,
-    z => 0.0]
+u0 = [x => 1.0,
+    y => 1.0]
 
-p = [σ => 28.0,
-    ρ => 10.0,
-    β => 8 / 3]
+p = [α => 2/3,
+    β => 4/3,
+    γ => 1,
+    δ => 1]
 
-tspan = (0.0, 100.0)
+tspan = (0.0, 50.0)
 prob = ODEProblem(sys, u0, tspan, p, jac = true)
 sol = solve(prob)
 
-tsave = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+tsave = collect(1.0:1:10)
 sol_data = solve(prob, saveat = tsave)
-data = [x => sol_data[x], z => sol_data[z]]
-psub_ini = [σ => 27.0, β => 3.0]
+data = [x => sol_data[x], y => sol_data[y]]
+psub_ini = [α => 1.0,
+    β => 1.2,
+    γ => 0.9,
+    δ => 0.8]
 fit = datafit(prob, psub_ini, tsave, data)
 pvals_fit = getfield.(fit, :second)
-pvals = getfield.(p, :second)[[1, 3]]
+pvals = getfield.(p, :second)
 @test isapprox(pvals, pvals_fit, atol = 1e-4, rtol = 1e-4)
 
-tsave1 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+tsave1 = collect(1.0:1:10)
 sol_data1 = solve(prob, saveat = tsave1)
-tsave2 = [0.5, 1.5, 2.5, 3.5]
+tsave2 = collect(0.5:1:5)
 sol_data2 = solve(prob, saveat = tsave2)
-data_with_t = [x => (tsave1, sol_data1[x]), z => (tsave2, sol_data2[z])]
+data_with_t = [x => (tsave1, sol_data1[x]), y => (tsave2, sol_data2[y])]
 
 fit = datafit(prob, psub_ini, data_with_t)
 pvals_fit = getfield.(fit, :second)
-pvals = getfield.(p, :second)[[1, 3]]
+pvals = getfield.(p, :second)
 @test isapprox(pvals, pvals_fit, atol = 1e-4, rtol = 1e-4)
 
 prob2 = remake(prob, p = fit)
@@ -50,50 +51,58 @@ scores = model_forecast_score([prob, prob2, prob3], tsave, data)
 @test scores[2] < 2e-3
 @test scores[3] > 2
 
-psub_ini = [σ => [27.0, 29.0], β => [2.0, 3.0]]
+
+psub_ini = [
+    α => [0.5, 0.9],
+    β => [0.9, 1.5],
+    γ => [0.7, 1.4],
+    δ => [0.5, 1.5]
+]
 fit = global_datafit(prob, psub_ini, tsave, data)
 pvals_fit = getfield.(fit, :second)
-pvals = getfield.(p, :second)[[1, 3]]
+pvals = getfield.(p, :second)
 @test isapprox(pvals, pvals_fit, atol = 1e-4, rtol = 1e-4)
 
 fit = global_datafit(prob, psub_ini, data_with_t)
 pvals_fit = getfield.(fit, :second)
-pvals = getfield.(p, :second)[[1, 3]]
+pvals = getfield.(p, :second)
 @test isapprox(pvals, pvals_fit, atol = 1e-4, rtol = 1e-4)
 
-@variables x_2(t)
-eqs_obs = [D(x) ~ σ * (y - x),
-    D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z,
-    x_2 ~ 2 * x]
+@parameters α β γ δ
+@variables x(t) y(t) x_2(t)
+
+eqs_obs = [D(x) ~ α * x - β * x * y,
+    D(y) ~ -γ * y + δ * x * y,
+    x_2 ~ 2*x]
 
 @mtkbuild sys_obs = ODESystem(eqs_obs, t)
 
-u0_obs = [D(x) => 2.0,
+u0_obs = [
     x => 1.0,
-    y => 0.0,
-    z => 0.0,
+    y => 1.0,
     x_2 => 2.0]
 
 prob_obs = ODEProblem(sys_obs, u0_obs, tspan, p, jac = true)
 sol_data_obs = solve(prob_obs, saveat = tsave)
-data_obs = [x_2 => sol_data_obs[x_2], z => sol_data_obs[z]]
+data_obs = [x_2 => sol_data_obs[x_2], y => sol_data_obs[y]]
 fit_obs = global_datafit(prob_obs, psub_ini, tsave, data_obs)
 pvals_fit_obs = getfield.(fit_obs, :second)
 @test isapprox(pvals, pvals_fit_obs, atol = 1e-4, rtol = 1e-4)
 
-tsave = collect(10.0:10.0:100.0)
+tsave = collect(1.0:1.0:10.0)
 sol_data = solve(prob, saveat = tsave)
-data = [x => sol_data[x], z => sol_data[z]]
-p_prior = [σ => Normal(26.8, 0.1), β => Normal(2.7, 0.1)]
+data = [x => sol_data[x], y => sol_data[y]]
+
+
+p_prior = [α => Normal(2/3, 0.1), β => Normal(4/3,0.1), γ => Normal(1, 0.1), δ => Normal(1, 0.1)]
 p_posterior = @time bayesian_datafit(prob, p_prior, tsave, data, niter = 3000)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))
 
-tsave1 = collect(10.0:10.0:100.0)
+tsave1 = collect(1.0:1.0:10.0)
 sol_data1 = solve(prob, saveat = tsave1)
-tsave2 = collect(10.0:13.5:100.0)
+tsave2 = collect(1.0:2.0:10.0)
 sol_data2 = solve(prob, saveat = tsave2)
-data_with_t = [x => (tsave1, sol_data1[x]), z => (tsave2, sol_data2[z])]
+data_with_t = [x => (tsave1, sol_data1[x]), y => (tsave2, sol_data2[y])]
 
 p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 5000)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))

--- a/test/datafit.jl
+++ b/test/datafit.jl
@@ -86,7 +86,7 @@ tsave = collect(10.0:10.0:100.0)
 sol_data = solve(prob, saveat = tsave)
 data = [x => sol_data[x], z => sol_data[z]]
 p_prior = [σ => Normal(26.8, 0.1), β => Normal(2.7, 0.1)]
-p_posterior = @time bayesian_datafit(prob, p_prior, tsave, data, niter = 40)
+p_posterior = @time bayesian_datafit(prob, p_prior, tsave, data, niter = 3000)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))
 
 tsave1 = collect(10.0:10.0:100.0)
@@ -95,5 +95,5 @@ tsave2 = collect(10.0:13.5:100.0)
 sol_data2 = solve(prob, saveat = tsave2)
 data_with_t = [x => (tsave1, sol_data1[x]), z => (tsave2, sol_data2[z])]
 
-p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 40)
+p_posterior = @time bayesian_datafit(prob, p_prior, data_with_t, niter = 3000)
 @test var.(getfield.(p_prior, :second)) >= var.(getfield.(p_posterior, :second))

--- a/test/ensemble.jl
+++ b/test/ensemble.jl
@@ -1,8 +1,8 @@
 using EasyModelAnalysis, LinearAlgebra, Test
+using ModelingToolkit: t_nounits as t, D_nounits as ∂ 
 
-@parameters t β=0.05 c=10.0 γ=0.25
+@parameters β=0.05 c=10.0 γ=0.25
 @variables S(t)=990.0 I(t)=10.0 R(t)=0.0
-∂ = Differential(t)
 N = S + I + R # This is recognized as a derived variable
 eqs = [∂(S) ~ -β * c * I / N * S,
     ∂(I) ~ β * c * I / N * S - γ * I,
@@ -12,9 +12,8 @@ eqs = [∂(S) ~ -β * c * I / N * S,
 tspan = (0, 30)
 prob = ODEProblem(sys, [], tspan);
 
-@parameters t β=0.1 c=10.0 γ=0.25 ρ=0.1 h=0.1 d=0.1 r=0.1
+@parameters β=0.1 c=10.0 γ=0.25 ρ=0.1 h=0.1 d=0.1 r=0.1
 @variables S(t)=990.0 I(t)=10.0 R(t)=0.0 H(t)=0.0 D(t)=0.0
-∂ = Differential(t)
 N = S + I + R + H + D # This is recognized as a derived variable
 eqs = [∂(S) ~ -β * c * I / N * S,
     ∂(I) ~ β * c * I / N * S - γ * I - h * I - ρ * I,
@@ -26,13 +25,12 @@ eqs = [∂(S) ~ -β * c * I / N * S,
 
 prob2 = ODEProblem(sys2, [], tspan);
 
-@parameters t β=0.1 c=10.0 γ=0.25 ρ=0.1 h=0.1 d=0.1 r=0.1 v=0.1
-@parameters t β2=0.1 c2=10.0 ρ2=0.1 h2=0.1 d2=0.1 r2=0.1
+@parameters β=0.1 c=10.0 γ=0.25 ρ=0.1 h=0.1 d=0.1 r=0.1 v=0.1
+@parameters β2=0.1 c2=10.0 ρ2=0.1 h2=0.1 d2=0.1 r2=0.1
 @variables S(t)=990.0 I(t)=10.0 R(t)=0.0 H(t)=0.0 D(t)=0.0
 @variables Sv(t)=0.0 Iv(t)=0.0 Rv(t)=0.0 Hv(t)=0.0 Dv(t)=0.0
 @variables I_total(t)
 
-∂ = Differential(t)
 N = S + I + R + H + D + Sv + Iv + Rv + Hv + Dv # This is recognized as a derived variable
 eqs = [∂(S) ~ -β * c * I_total / N * S - v * Sv,
     ∂(I) ~ β * c * I_total / N * S - γ * I - h * I - ρ * I,

--- a/test/ensemble.jl
+++ b/test/ensemble.jl
@@ -1,5 +1,5 @@
 using EasyModelAnalysis, LinearAlgebra, Test
-using ModelingToolkit: t_nounits as t, D_nounits as ∂ 
+using ModelingToolkit: t_nounits as t, D_nounits as ∂
 
 @parameters β=0.05 c=10.0 γ=0.25
 @variables S(t)=990.0 I(t)=10.0 R(t)=0.0

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,7 +1,7 @@
 # A SIR
 using EasyModelAnalysis
-@variables t
-Dₜ = Differential(t)
+using ModelingToolkit: t_nounits as t, D_nounits as Dₜ
+
 @variables S(t)=0.9 Iₐ(t)=0.05 Iₛ(t)=0.01 Rₐ(t)=0.2 Rₛ(t)=0.1 D(t)=0.01
 @parameters α=0.6 βₐ=0.143 βₛ=0.055 ρ=0.003 μₙ=0.007 μₘ=0.011 θ=0.1 ωₛ=0.14
 eqs = [Dₜ(S) ~ μₙ * S - μₘ * S - θ * α * S * Iₛ - (1 - θ) * α * S * Iₐ + ρ * (Rₐ + Rₛ)
@@ -20,9 +20,6 @@ using Test
 @test imax > 0.3
 
 # SEIRHD
-using EasyModelAnalysis
-@variables t
-Dₜ = Differential(t)
 @variables S(t)=0.9 E(t)=0.05 I(t)=0.01 R(t)=0.2 H(t)=0.1 D(t)=0.01 T(t)=0.0 η(t)=0.0
 @parameters β₁=0.6 β₂=0.143 β₃=0.055 α=0.003 γ₁=0.007 γ₂=0.011 δ=0.1 μ=0.14
 eqs = [T ~ S + E + I + R + H + D

--- a/test/sensitivity.jl
+++ b/test/sensitivity.jl
@@ -1,8 +1,8 @@
 using EasyModelAnalysis, Test
+using ModelingToolkit: t_nounits as t, D_nounits as D
 
-@parameters t σ ρ β
+@parameters σ ρ β
 @variables x(t) y(t) z(t)
-D = Differential(t)
 
 eqs = [D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,

--- a/test/threshold.jl
+++ b/test/threshold.jl
@@ -32,9 +32,8 @@ sol = stop_at_threshold(prob, x^2, 0.1)
 @test sol.u[end][1]^2≈0.1 atol=1e-5
 
 # Intervention
-@variables t x(t)
+@variables x(t)
 @parameters p
-D = Differential(t)
 eqs = [D(x) ~ p * x]
 @mtkbuild sys = ODESystem(eqs, t)
 prob = ODEProblem(sys, [x => 0.01], (0.0, 50), [p => 1.0])
@@ -78,9 +77,8 @@ opt_ps, (s1, s2, s3), ret = optimal_parameter_intervention_for_reach(
     maxtime = 10);
 @test 10 < opt_ps[p]
 
-@variables t x(t) y(t)
+@variables x(t) y(t)
 @parameters p1 p2
-D = Differential(t)
 eqs = [D(x) ~ p1 * abs(x) + p2 * y
        D(y) ~ p1 * abs(x) + p2 * y]
 @mtkbuild sys = ODESystem(eqs, t)
@@ -92,9 +90,8 @@ opt_ps, s2, ret = optimal_parameter_threshold(prob, x, 2, p1 - p2, [p1, p2],
 @test s2.u[end][1] < 2
 @test abs(opt_ps[p2]) - abs(opt_ps[p1]) + 0.1 < 0
 
-@parameters t σ ρ β
+@parameters σ ρ β
 @variables x(t) y(t) z(t)
-D = Differential(t)
 
 eqs = [D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,

--- a/test/threshold.jl
+++ b/test/threshold.jl
@@ -1,8 +1,8 @@
 using EasyModelAnalysis, Test
+using ModelingToolkit: t_nounits as t, D_nounits as D
 
-@parameters t σ ρ β
+@parameters σ ρ β
 @variables x(t) y(t) z(t)
-D = Differential(t)
 
 eqs = [D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
@@ -24,8 +24,7 @@ prob = ODEProblem(sys, u0, tspan, p, jac = true)
 sol = solve(prob)
 
 # Threshold
-@variables t x(t)
-D = Differential(t)
+@variables x(t)
 eqs = [D(x) ~ x]
 @mtkbuild sys = ODESystem(eqs, t)
 prob = ODEProblem(sys, [x => 0.01], (0.0, Inf))


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This changes the tests to use the new things like `t_nounits` and `D_nounits` instead of declaring a parameter `t` and `Differential` for every model. This makes it more idiomatic.

Also changed the `datafit` tests to use the normal Lorenz system instead of the modified one. I think some issues with the CI were being caused because the `bayesian_datafit`s were testing a lot of parameters that made the system difficult to solve, which caused the CI to time out. This also meant I had to give the optimizers a few more timesteps to be in tolerance, but the tests run much faster now. 

This also updates to Turing 0.33. I could try to seperate that out, but for some reason when I try to downgrade to 0.30 to test I get precompilation errors that I haven't been able to work out. 