### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EasyModelAnalysis"
 uuid = "ef4b24a4-a090-4686-a932-e7e56a5a83bd"
 authors = ["SciML"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
@@ -33,7 +33,7 @@ OptimizationNLopt = "0.2, 0.3"
 Plots = "1"
 Reexport = "1"
 SafeTestsets = "0.1"
-SciMLBase = "2.54"
+SciMLBase = "2.54, 3.1"
 SciMLExpectations = "2"
 Test = "1"
 Turing = "0.33, 0.34, 0.35, 0.36"


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

Extend `SciMLBase` compat to include v3.1 (keep the existing lower bound and v2 support). No code changes required — a grep of `src/` and `test/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, single-int non-scalar timeseries `sol[i]` indexing, or removed getproperty aliases like `.destats` / `.minimizer`).

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54` while SciMLBase 3.1 requires RAT v4. Expect CI on this PR to fail at the `Pkg.add` step with an unsatisfiable resolution error until upstream OrdinaryDiffEq releases a RAT-v4-compatible version; re-running afterward should go green without further edits.

## Context

Part of the SciMLBase v3 ecosystem sweep — see SciML/DiffEqCallbacks.jl#300 and SciML/DiffEqParamEstim.jl#290 for the reference patterns for code-side changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)