### PR TITLE
Use SciMLTesting v1.0.0 (run_tests harness)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ Reexport = "1"
 SafeTestsets = "0.1"
 SciMLBase = "2.54, 3.1"
 SciMLExpectations = "2"
+SciMLTesting = "1"
 Test = "1"
 Turing = "0.33, 0.34, 0.35, 0.36, 0.45"
 julia = "1.10"
@@ -42,7 +43,8 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "SafeTestsets", "Test"]
+test = ["Aqua", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using SafeTestsets, Test
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-@time begin
-    if GROUP == "All" || GROUP == "Core"
+run_tests(;
+    core = () -> begin
         @testset "Core" begin
             @time @safetestset "Quality Assurance" include("qa.jl")
             @time @safetestset "Basic Tests" include("basics.jl")
@@ -12,9 +11,11 @@ const GROUP = get(ENV, "GROUP", "All")
             @time @safetestset "Threshold Tests" include("threshold.jl")
             @time @safetestset "Example Tests" include("examples.jl")
         end
-    end
-
-    if GROUP == "All" || GROUP == "Datafit"
-        @time @safetestset "Datafit Tests" include("datafit.jl")
-    end
-end
+    end,
+    groups = Dict(
+        "Datafit" => () -> begin
+            @time @safetestset "Datafit Tests" include("datafit.jl")
+        end,
+    ),
+    all = ["Core", "Datafit"],
+)


### PR DESCRIPTION
Replace the hand-written `GROUP`-dispatch in `test/runtests.jl` with a single declarative `SciMLTesting.run_tests` call (SciMLTesting v1.0.0).

This is a pure, behavior-equivalent harness refactor — same group routing and same test bodies, just driven by `run_tests` instead of a copy-pasted `if GROUP == ...` ladder.

**Routing:** `core` = the `Core` testset (qa/basics/sensitivity/ensemble/threshold/examples, run in the main test env); `groups["Datafit"]` = `datafit.jl` (no sub-env, so it also runs under `"All"`). No `Pkg` was present in the test deps, so none was removed.

**Project.toml:** add `SciMLTesting` to `[extras]`, `[targets].test`, and `[compat]` (`= "1"`).

Verified statically (TOML parse + `Meta.parseall` of `runtests.jl`) and the dispatch was checked against the real `run_tests` with marker thunks to confirm each `GROUP` selects the same bodies as before. Heavy suites left to CI.

Ignore until reviewed by @ChrisRackauckas.