### PR TITLE
Import AbstractMCMC to fix package precompilation (UndefVarError)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "EasyModelAnalysis"
 uuid = "ef4b24a4-a090-4686-a932-e7e56a5a83bd"
 authors = ["SciML"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
+AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GlobalSensitivity = "af5da776-676b-467e-8baf-acd8249e4f0f"
@@ -20,6 +21,7 @@ SciMLExpectations = "afe9f18d-7609-4d0e-b7b7-af0cb72b8ea8"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
+AbstractMCMC = "4, 5"
 Aqua = "0.8"
 DifferentialEquations = "7, 8.0"
 Distributions = "0.25"

--- a/src/EasyModelAnalysis.jl
+++ b/src/EasyModelAnalysis.jl
@@ -7,6 +7,7 @@ using Reexport
 @reexport using Distributions
 using Optimization, OptimizationBBO, OptimizationNLopt
 using GlobalSensitivity, Turing
+using AbstractMCMC
 using SciMLExpectations
 @reexport using Plots
 using SciMLBase.EnsembleAnalysis


### PR DESCRIPTION
## Problem

`main` CI is red across four checks (Core, Datafit, QA ×2 Julia 1/lts, and Documentation build). All fail at the same root cause: the package no longer precompiles.

```
ERROR: LoadError: UndefVarError: `AbstractMCMC` not defined in `EasyModelAnalysis`
Hint: AbstractMCMC is loaded but not imported in the active module Main.
  @ ~/.../src/datafit.jl:262
```

The `mcmcensemble` keyword of both `bayesian_datafit` methods is annotated `AbstractMCMC.AbstractMCMCEnsemble` (added in commit `6a350b8`, July 2023), but `AbstractMCMC` was never imported into the module. It was only reachable transitively because older Turing versions re-exported the bare `AbstractMCMC` binding. The Turing version now resolved in CI no longer brings `AbstractMCMC` into the module's scope, so the type annotation fails at precompile/load time and every test group + the docs build dies before running.

## Fix

Declare `AbstractMCMC` as a direct dependency and `using AbstractMCMC`. This is the symbol the source actually references. `AbstractMCMC` was already present transitively in the resolved environment (v5.15.1), so no manifest/version churn beyond declaring it. Compat set to `4, 5` (the `AbstractMCMCEnsemble` abstract type has been stable across both).

## Local verification (Julia 1.10)

Reproduced the failure on a clean `main` checkout (package failed to load), then confirmed the fix:

```
  23504.7 ms  ✓ EasyModelAnalysis
RESULT: LOADED OK
AbstractMCMCEnsemble resolves: AbstractMCMC.AbstractMCMCEnsemble
bayesian_datafit methods: 2
```

The package now precompiles and loads, and both `bayesian_datafit` method signatures resolve.

Please ignore until reviewed by @ChrisRackauckas.
