### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,6 +62,7 @@ makedocs(
             "api/data_fitting_calibration.md",
             "api/sensitivity_analysis.md",
             "api/threshold_interventions.md",
+            "api/ensemble_modeling.md",
         ],
     ]
 )

--- a/docs/src/api/data_fitting_calibration.md
+++ b/docs/src/api/data_fitting_calibration.md
@@ -4,4 +4,5 @@
 datafit
 global_datafit
 bayesian_datafit
+model_forecast_score
 ```

--- a/docs/src/api/ensemble_modeling.md
+++ b/docs/src/api/ensemble_modeling.md
@@ -1,0 +1,6 @@
+# Ensemble Modeling
+
+```@docs
+bayesian_ensemble
+ensemble_weights
+```

--- a/docs/src/api/sensitivity_analysis.md
+++ b/docs/src/api/sensitivity_analysis.md
@@ -2,5 +2,6 @@
 
 ```@docs
 get_sensitivity
+get_sensitivity_of_maximum
 create_sensitivity_plot
 ```

--- a/docs/src/api/threshold_interventions.md
+++ b/docs/src/api/threshold_interventions.md
@@ -2,6 +2,10 @@
 
 ```@docs
 stop_at_threshold
+get_threshold
+prob_violating_threshold
 optimal_threshold_intervention
 optimal_parameter_intervention_for_threshold
+optimal_parameter_threshold
+optimal_parameter_intervention_for_reach
 ```

--- a/src/ensemble.jl
+++ b/src/ensemble.jl
@@ -48,6 +48,48 @@ end
 (f::EnsembleProbForwarder)(prob, i::Integer, repeat) = f.all_probs[i]
 (f::EnsembleProbForwarder)(prob, ctx) = f.all_probs[ctx.sim_id]
 
+"""
+    bayesian_ensemble(probs, ps, datas;
+        noise_prior = InverseGamma(2, 3),
+        mcmcensemble = Turing.MCMCSerial(),
+        nchains = 4, niter = 1_000, keep = 100)
+
+Build an ensemble of calibrated models by Bayesian-fitting each model to its own data
+and collecting posterior samples of the fitted problems into a single `EnsembleProblem`.
+
+For each model, [`bayesian_datafit`](@ref) is run to obtain posterior samples of the
+parameters, and the last `keep` posterior draws are turned into `remake`d problems (one
+problem per draw). The problems from all models are concatenated, and the returned
+`EnsembleProblem` uses an internal `prob_func` that selects the `i`th collected problem so
+that the `i`th trajectory solves it. Solving the returned problem with
+`trajectories = length(enprob.prob_func.all_probs)` therefore samples the full posterior
+ensemble across all models.
+
+## Arguments
+
+  - `probs`: a vector of `ODEProblem`s, one per model to be calibrated.
+  - `ps`: a vector where the `i`th entry is the parameter specification (a vector of
+    symbolic-parameter `=> prior` pairs) passed to [`bayesian_datafit`](@ref) for `probs[i]`.
+  - `datas`: a vector where the `i`th entry is the data (of the form accepted by
+    [`bayesian_datafit`](@ref)) used to calibrate `probs[i]`.
+
+## Keyword Arguments
+
+  - `noise_prior`: prior distribution on the observation noise passed to
+    [`bayesian_datafit`](@ref). Defaults to `InverseGamma(2, 3)`.
+  - `mcmcensemble`: the Turing MCMC ensemble strategy used for sampling. Defaults to
+    `Turing.MCMCSerial()`.
+  - `nchains`: number of MCMC chains per model. Defaults to `4`.
+  - `niter`: number of MCMC iterations per chain. Defaults to `1_000`.
+  - `keep`: number of posterior draws (from the tail of the chain) kept per model to form
+    the ensemble. Defaults to `100`.
+
+# Returns
+
+  - An `EnsembleProblem` whose trajectories correspond to the collected posterior-sample
+    problems from all models. Use the resulting ensemble solution together with
+    [`ensemble_weights`](@ref) to weight the models against data.
+"""
 function bayesian_ensemble(
         probs, ps, datas;
         noise_prior = InverseGamma(2, 3),

--- a/src/threshold.jl
+++ b/src/threshold.jl
@@ -57,9 +57,23 @@ function _threshold_violation(threshold)
 end
 
 """
-    prob_violating_thresholdd(prob, p, thresholds)
+    prob_violating_threshold(prob, p, thresholds)
 
 Returns the probability of violating `thresholds` given distributions of parameters `p`.
+
+## Arguments
+
+  - `prob`: An `ODEProblem`.
+  - `p`: a vector of pairs from symbolic parameters to the distributions describing their
+    uncertainty, e.g. `[α => Uniform(0.0, 1.0)]`.
+  - `thresholds`: a vector of symbolic inequality expressions (e.g. `[x > 10.0, y < 1.0]`)
+    that define the violating region. An `x > bound` threshold is violated when the state
+    `x` exceeds `bound` at any saved time, and `x < bound` when it falls below it.
+
+# Returns
+
+  - The probability (a scalar in `[0, 1]`) that at least one threshold is violated,
+    computed as the Koopman expectation of the violation indicator over `p`.
 """
 function prob_violating_threshold(prob, p, thresholds)
     pkeys = getfield.(p, :first)


### PR DESCRIPTION
## Summary

Ensures every public/exported name in EasyModelAnalysis has **both** an interface docstring **and** a rendered `@docs` entry.

Authoritative audit (loading the package on Julia 1.12 and enumerating EasyModelAnalysis-owned public names via `names(EasyModelAnalysis; all=false)` filtered to `binding_module === EasyModelAnalysis`) found that of the 26 owned public names, only `bayesian_ensemble` was genuinely missing a docstring; the other flagged names already had docstrings but were **not rendered** in the manual.

### Changes

- **`bayesian_ensemble`**: added a full docstring (it was previously undocumented — the neighboring docstring belonged to the internal `EnsembleProbForwarder`).
- **`prob_violating_threshold`**: fixed the docstring signature (was `prob_violating_thresholdd`, a typo) and documented its arguments and return value.
- **Rendered-docs entries** added for the public names that had docstrings but no `@docs` block:
  - `api/sensitivity_analysis.md`: `get_sensitivity_of_maximum`
  - `api/data_fitting_calibration.md`: `model_forecast_score`
  - `api/threshold_interventions.md`: `get_threshold`, `prob_violating_threshold`, `optimal_parameter_threshold`, `optimal_parameter_intervention_for_reach`
  - new `api/ensemble_modeling.md` (registered in `docs/make.jl`): `bayesian_ensemble`, `ensemble_weights`

### Validation

- Loaded the package: all 26 EasyModelAnalysis-owned public names now have an attached docstring (`Base.Docs.doc` non-empty).
- Ran an isolated Documenter build of the API reference pages: `CrossReferences` and `CheckDocument` pass with no "docstring not found" / unresolved-`@docs` errors for any of these names (the only remaining `:missing_docs` warnings are for the intentionally-internal `EnsembleProbForwarder` and `_pprior_samples`, which are not part of the public API and are already tolerated by the repo's `warnonly = [:missing_docs, :example_block]`).

Docstrings were written from the actual implementations, not invented.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)