### PR TITLE
Release version 1.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EasyModelAnalysis"
 uuid = "ef4b24a4-a090-4686-a932-e7e56a5a83bd"
 authors = ["SciML"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"


### PR DESCRIPTION
## What changed and why

Bump EasyModelAnalysis from 1.3.0 to the next consecutive minor release, 1.4.0. This publishes the documented public-surface restoration merged in https://github.com/SciML/EasyModelAnalysis.jl/pull/327; the minor bump matches the policy for new public API in a package at major version 1.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Run locally on the exact release commit with Julia 1.12.6:

```text
GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA/qa.jl      |   21     21  14m41.0s
Testing EasyModelAnalysis tests passed

julia --project -e 'using Pkg; Pkg.test()'
Core/basics.jl              9/9    18m13.2s
Core/ensemble.jl            1/1    31m04.1s
Core/examples.jl            4/4         7.8s
Core/precompile_workload.jl 1/1         0.2s
Core/sensitivity.jl         4/4    72m10.6s
Core/threshold.jl          12/12    7m17.8s
Datafit/datafit.jl         10/10   12m09.3s
Testing EasyModelAnalysis tests passed

julia --project=@runic -e 'using Runic; exit(Runic.main(["--check", "."]))'
exit 0

git diff --check
exit 0

git diff --unified=0 | typos --format brief -
exit 0
```

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

CI note: Documentation fails during `Pkg.develop`/resolution with the Catlab/DataStructures/SymbolicUtils incompatibility recorded in the handoff as pre-existing: https://github.com/SciML/EasyModelAnalysis.jl/actions/runs/32902642041/job/97979687942. This version-only PR remains draft while that clean-main classification is independently re-audited.

AI agent continuation: OpenAI Codex
Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
