### PR TITLE
qa: use shared reexport documentation policy

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -74,7 +74,6 @@ const REEXPORTS = (
 run_qa(
     EasyModelAnalysis;
     reexports_allow = REEXPORTS,
-    api_docs_kwargs = (; ignore = REEXPORTS, rendered_ignore = REEXPORTS),
     # The reexported names are brought into scope by the bare `using` of each upstream
     # package in src/EasyModelAnalysis.jl; they are reexported, not used, so they are not
     # implicit imports that should be made explicit.


### PR DESCRIPTION
Removes the repository-specific `api_docs_kwargs` exemption for the explicitly documented EasyModelAnalysis reexport facade. This depends on https://github.com/SciML/SciMLTesting.jl/pull/62, which makes `reexports_allow` exempt only approved external bindings from the facade package’s local-docstring ownership check; all package-owned public API remains strict.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `git diff --check`
- `typos test/qa/qa.jl`
- `julia --startup-file=no --project=docs docs/make.jl` (passed; Documenter emitted only existing size/glyph warnings)
- `julia --startup-file=no --project=.qa-env -e 'include("test/qa/qa.jl")'` with the SciMLTesting source from PR 62: `Quality Assurance | 20 / 20`, `Reexport surface | 1 / 1`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791