### PR TITLE
Drop dangling shape reexport

### DIFF
--- a/docs/src/api/reexports.md
+++ b/docs/src/api/reexports.md
@@ -123,7 +123,7 @@ their results.
     `cquantile`, `insupport`, `support`
   - Statistics: `mean`, `median`, `mode`, `modes`, `var`, `std`, `cov`, `cor`,
     `skewness`, `kurtosis`, `entropy`, `kldivergence`, `loglikelihood`
-  - Parameters: `params`, `partype`, `location`, `scale`, `shape`, `rate`, `probs`,
+  - Parameters: `params`, `partype`, `location`, `scale`, `rate`, `probs`,
     `ncategories`, `ntrials`, `succprob`, `failprob`
   - Fitting and sampling: `fit`, `fit_mle`, `sampler`
   - The `Distributions` module itself, for qualified access

--- a/src/EasyModelAnalysis.jl
+++ b/src/EasyModelAnalysis.jl
@@ -100,7 +100,7 @@ export Arcsine, Bernoulli, Beta, Binomial, Categorical, Cauchy, ccdf, cdf, censo
     MixtureModel, mode, modes, Multinomial, Multivariate, MultivariateDistribution,
     MvLogNormal, MvNormal, ncategories, NegativeBinomial, Normal, ntrials, params, Pareto,
     partype, pdf, Poisson, probs, Product, product_distribution, quantile, rate, Rayleigh,
-    Sampleable, sampler, scale, shape, skewness, SkewNormal, std, succprob, support, TDist,
+    Sampleable, sampler, scale, skewness, SkewNormal, std, succprob, support, TDist,
     Truncated, truncated, Uniform, Univariate, UnivariateDistribution, var, Weibull, Wishart
 
 # Reexported Plots API: the plotting verbs and attribute helpers the analysis plots and

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -55,7 +55,7 @@ const REEXPORTS = (
     :RODEProblem, :RODESolution, :Rosenbrock23, :Sampleable, :sampler, :SampleTime,
     :savefig, :savevalues!, :scale, :scatter, :scatter!, :scatter3d, :scatter3d!,
     :SciMLBase, :SDEFunction, :SDEProblem, :SDESystem, :SecondOrderODEProblem,
-    Symbol("@series"), :set_proposed_dt!, :Shape, :shape, :Shift, :ShiftIndex, :showtheme,
+    Symbol("@series"), :set_proposed_dt!, :Shape, :Shift, :ShiftIndex, :showtheme,
     :simplify, :skewness, :SkewNormal, :solve, :solve!, :SplitFunction, :SplitODEProblem,
     :spy, :spy!, :std, :SteadyStateProblem, :SteadyStateSolution, :step!, :stephist,
     :stephist!, :sticks, :sticks!, :Stream, :stroke, :structural_simplify, :substitute,


### PR DESCRIPTION
## Change

`shape` is exported by both Distributions and Plots, so the bare `using`s in `src/EasyModelAnalysis.jl` leave the binding ambiguous and `EasyModelAnalysis.shape` is undefined. That trips two QA checks on master: Aqua's `undefined_exports` (`Symbol("EasyModelAnalysis.shape")`) and the reexport-surface reachability test (`isempty([:shape])`).

Since the name is unreachable for users today (any `EasyModelAnalysis.shape` access throws), dropping it from the `export` list — and from the `REEXPORTS` allow-list and the documented parameter list — is not breaking. Users can still reach `Distributions.shape` via `using Distributions`.

## Verification

On master, `names(EasyModelAnalysis)` contains `shape` while `isdefined(EasyModelAnalysis, :shape)` is `false` (ambiguous Distributions/Plots binding) — reproducing the Aqua failure. After this change `shape` is no longer in `names(EasyModelAnalysis)` or `REEXPORTS`, so both checks pass. Native QA on CI pending (previous revision passed QA 23/23 locally).

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL