### PR TITLE
Fix uncertainty forecast trajectory indexing

### DIFF
--- a/src/basics.jl
+++ b/src/basics.jl
@@ -199,7 +199,7 @@ function get_uncertainty_forecast(prob, sym, t, uncertainp, samples)
     prob_func(prob, ctx) = sample_prob(prob)
     eprob = EnsembleProblem(prob, prob_func = prob_func)
     esol = solve(eprob, nothing, EnsembleSerial(), saveat = t, trajectories = samples)
-    return Array.(reduce.(hcat, [esol[i][sym] for i in 1:samples]))
+    return Array.(reduce.(hcat, [esol.u[i][sym] for i in 1:samples]))
 end
 
 """

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -48,6 +48,17 @@ quantiles = get_uncertainty_forecast_quantiles(
 @test length(quantiles) == 2
 @test all(size(q) == (length(t_measure), 1) for q in quantiles)
 
+@testset "Uncertainty forecast trajectories" begin
+    for (symbols, initial_values) in ((x, [1.0]), ([x], [1.0]), ([x, y], [1.0, 0.0]))
+        forecasts = get_uncertainty_forecast(
+            prob, symbols, t_measure, [σ => Uniform(27.0, 29.0)], 4
+        )
+        @test length(forecasts) == 4
+        @test all(size(forecast) == (length(initial_values), length(t_measure)) for forecast in forecasts)
+        @test all(forecast[:, 1] == initial_values for forecast in forecasts)
+    end
+end
+
 xmin, xminval = get_min_t(prob, x)
 @test sol(xmin; idxs = x) == xminval
 @test sol(xmin; idxs = x) <= minimum(sol[x])


### PR DESCRIPTION
## Change

Read each trajectory from `esol.u[i]` in `get_uncertainty_forecast`. With current ensemble array indexing, `esol[i]` is a scalar, so the subsequent symbolic selection throws instead of returning forecast matrices. The new official regression covers scalar, one-element-vector, and multiple-variable selections, including output shape and initial values.

Rebased onto main — no longer stacked on #336 (the shape-reexport change is independent).

## Verification

Julia 1.11.9 standalone public-API probe, identical 433-entry dependency graph except the EasyModelAnalysis source path:

```text
Before (018c4e5a315138f4d8c0a01b64601f76c590d714):
Forecast trajectory indexing | 3 errors | 22.3s
x(t), [x(t)], and [x(t), y(t)] all fail at scalar ensemble indexing.

After:
Forecast trajectory indexing | 9 pass | 15.1s
exit 0
```

The probe constructs `D(x) ~ -k*x`, `D(y) ~ k*x`, with initial `[1.0, 0.0]`, requests two trajectories at `[0.0, 0.5, 1.0]`, and checks the returned sample count, variable-by-time matrix shape, and exact initial column. It does not loosen tolerances or remove sampling.

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL