### PR TITLE
Source Integrals/MonteCarloIntegration from master in test env

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,9 +46,14 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+MonteCarloIntegration = "4886b29c-78c9-11e9-0a6e-41e1f4161f7b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["Aqua", "MonteCarloIntegration", "SafeTestsets", "SciMLTesting", "Test"]
+
+[sources]
+Integrals = {url = "https://github.com/SciML/Integrals.jl.git", rev = "master"}
+MonteCarloIntegration = {url = "https://github.com/ranjanan/MonteCarloIntegration.jl.git", rev = "master"}


### PR DESCRIPTION
## Summary

- The x86 CI lane failed during precompile: the registered `MonteCarloIntegration` v0.2.0 caps `QuasiMonteCarlo` at 0.3.x, which pins `LatticeRules` 0.0.1. On 32-bit Julia, `typemax(UInt32) + 1` in LatticeRules 0.0.1 wraps to zero (`ArgumentError: maximum number of points n must be less than or equal to 2^32`).
- `MonteCarloIntegration` master (v0.3.0, unregistered) allows `QuasiMonteCarlo` 0.4, which lifts `LatticeRules` to 0.0.2 where the arithmetic is widened.
- Adds `MonteCarloIntegration` to extras/test target and `[sources]` overrides for `Integrals` and `MonteCarloIntegration` (same approach as NeuralPDE.jl#1162 and BoundaryValueDiffEq.jl#634). Can be reverted once MCI 0.3.0 and a compatible Integrals are registered.
- Note: QA failures (`:shape` undefined export) are separately covered by #336.

#### Test plan

- [x] Fresh resolve + precompile on Julia 1.12.7 x86: resolves `QuasiMonteCarlo` 0.4.4, `LatticeRules` 0.0.2, `MonteCarloIntegration` 0.3.0, `Integrals` master — all precompile cleanly (previously `LatticeRules`/`QuasiMonteCarlo`/`MonteCarloIntegration`/`Integrals` all failed)

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max)
Session: /home/crackauc/.local/share/devin/cli/summaries/history_66ef0886b194479c.md