### PR TITLE
Remove contradictory SEIRHD observable defaults

### DIFF
--- a/docs/src/examples/SEIRHD.md
+++ b/docs/src/examples/SEIRHD.md
@@ -4,10 +4,12 @@ First, let's implement the classic SEIRHD epidemic model with ModelingToolkit:
 
 ```@example seirhd
 using DifferentialEquations, Distributions, EasyModelAnalysis, ModelingToolkit, Plots
+using SciMLBase: successful_retcode
 @independent_variables t
 Dₜ = Differential(t)
 @variables S(t)=0.9 E(t)=0.05 I(t)=0.01 R(t)=0.2 H(t)=0.1 D(t)=0.01
-@variables T(t)=0.0 η(t)=0.0 cumulative_I(t)=0.0
+@variables T(t) η(t)
+@variables cumulative_I(t)=0.0
 @parameters β₁=0.6 β₂=0.143 β₃=0.055 α=0.003 γ₁=0.007 γ₂=0.011 δ=0.1 μ=0.14
 eqs = [T ~ S + E + I + R + H + D
        η ~ (β₁ * E + β₂ * I + β₃ * H) / T
@@ -22,6 +24,10 @@ eqs = [T ~ S + E + I + R + H + D
 seirhd = structural_simplify(seirhd)
 prob = ODEProblem(seirhd, [], (0, 110.0))
 sol = solve(prob)
+@assert successful_retcode(sol)
+@assert [sol[state][1] for state in [S, E, I, R, H, D, cumulative_I]] ==
+    [0.9, 0.05, 0.01, 0.2, 0.1, 0.01, 0.0]
+@assert all(isfinite, Array(sol))
 plot(sol)
 ```
 


### PR DESCRIPTION
## Change

Remove contradictory initial defaults for the derived SEIRHD observables `T` and `η`. Preserve all compartment values (their sum is 1.27), cumulative infections, equations, and solver settings. Add executable return-code, initial-value, and finite-value assertions.

## Failing before / passing after

The same six-check initial-state regression failed 0/6 before and passed 6/6 after. The unfixed model produced a NaN initial timestep and remained at time zero; the corrected model returned Success and reached day 110 with T=1.27 and η≈0.02907874.

The actual five named documentation blocks were also evaluated, with the same added assertions in the before control:
```console
$ julia --startup-file=no --project=docs ../EMA-carcione-clean-env/run_seirhd_official_blocks.jl <unfixed-page-with-assertions>
AssertionError
[exit 1]
$ julia --startup-file=no --project=docs ../EMA-carcione-clean-env/run_seirhd_official_blocks.jl docs/src/examples/SEIRHD.md
SEIRHD_OFFICIAL_BLOCKS_OK 5
[exit 0]
```

Local native QA: 23/23 (7m52.3s); Core: 40/40, exit 0. New Julia fragments passed scoped formatting; spelling and diff checks passed.

**Full strict docs did not pass:** exit 124 at six hours, with 48 failed example blocks elsewhere. No SEIRHD block failure was logged, but the build did not complete. This change does not normalize the original compartment values or establish numerical validity of other examples.

## Validation scope

Historical results below were run locally with Julia 1.11.9 before rebasing onto current main (which now includes https://github.com/SciML/EasyModelAnalysis.jl/pull/336 and https://github.com/SciML/EasyModelAnalysis.jl/pull/337). The changed page is preserved by the rebase. These are not claims that the full documentation or all downstream packages pass. The user requested draft publication with these outstanding gates disclosed.

Native test/build commands, with a workspace-local TMPDIR and headless plotting:
```sh
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GKSwstype=100 timeout 21600 julia --startup-file=no --project=docs docs/make.jl
```
GPU paths, downstream packages, and deployment were not verified. No tests or documentation errors were disabled.

Please ignore this draft until reviewed by @ChrisRackauckas.
 
The post-rebase page is byte-identical to its locally validated pre-rebase version. Fresh post-rebase QA and focused page checks were launched on September 12 and remain pending at publication; they are not counted as passes. Post-rebase spelling and diff checks passed.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
