### PR TITLE
Remove contradictory scenario2 observable defaults

### DIFF
--- a/docs/src/scenarios/scenario2.md
+++ b/docs/src/scenarios/scenario2.md
@@ -10,7 +10,7 @@ Random.seed!(12345)
 @independent_variables t
 Dₜ = Differential(t)
 @variables S(t)=0.97 E(t)=0.02 I(t)=0.01 R(t)=0.0 H(t)=0.0 D(t)=0.0
-@variables T(t)=10000.0 η(t)=0.0 cumulative_I(t)=0.0
+@variables T(t) η(t) cumulative_I(t)=0.0
 @parameters β₁=0.06 β₂=0.015 β₃=0.005 α=0.003 γ₁=0.007 γ₂=0.001 δ=0.2 μ=0.04
 eqs = [T ~ S + E + I + R + H + D
        η ~ (β₁ * E + β₂ * I + β₃ * H)
@@ -25,6 +25,7 @@ eqs = [T ~ S + E + I + R + H + D
 seirhd = structural_simplify(seirhd)
 prob = ODEProblem(seirhd, [], (0.0, 60.0), saveat = 1.0)
 sol = solve(prob)
+@assert SciMLBase.successful_retcode(sol)
 u60 = sol[:, end]
 plot(sol)
 ```


### PR DESCRIPTION
## Change

Remove inconsistent initial defaults `T=10000` and `η=0` from scenario2's algebraic observables. Preserve all compartment values and cumulative_I(0)=0, and assert that the initial solve succeeds before using it as generated data. Event syntax, thresholds, optimizer, and budget are unchanged.

## Failing before / passing after

The same initial-state test checks successful return code, exact initial [S,E,I,R,H,D,T], and completion at day 60:
```console
$ julia --startup-file=no --project=docs ../EasyModelAnalysis-intervention-audit/.validation/test-initial-state.jl <unfixed-page>
Initial-state before: 0 passed, 3 failed; exit 1
$ julia --startup-file=no --project=docs ../EasyModelAnalysis-intervention-audit/.validation/test-initial-state.jl docs/src/scenarios/scenario2.md
Initial-state after: 3/3 passed; exit 0
```

Before: InitialFailure, t=0, initial [10000.06,.02,-.08,0,0,0,10000].
After: Success, t=60, initial [.97,.02,.01,0,0,0,1].

Local native QA: 23/23 (10m32s); Core: 31/31, exit 0. Scoped formatting, spelling, and diff checks passed.

**Full strict docs did not pass:** exit 124 at six hours, with 50 failed example blocks. Scenario2's subsequent intervention API failure is deliberately separate; this draft fixes initialization only.

## Validation scope

Historical results below were run locally with Julia 1.11.9 before rebasing onto current main (which now includes https://github.com/SciML/EasyModelAnalysis.jl/pull/336 and https://github.com/SciML/EasyModelAnalysis.jl/pull/337). The changed page is preserved by the rebase. These are not claims that the full documentation or all downstream packages pass. The user requested draft publication with these outstanding gates disclosed.

Native test/build commands, with a workspace-local TMPDIR and headless plotting:
```sh
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GKSwstype=100 timeout 21600 julia --startup-file=no --project=docs docs/make.jl
```
GPU paths, downstream packages, and deployment were not verified. No tests or documentation errors were disabled.

Please ignore this draft until reviewed by @ChrisRackauckas.
 
The post-rebase page is byte-identical to its locally validated pre-rebase version. Fresh post-rebase QA and focused page checks were launched on September 12 and remain pending at publication; they are not counted as passes. Post-rebase spelling and diff checks passed.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
