### PR TITLE
Migrate scenario2 intervention events to discrete variables

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,6 @@
+# Numerical example validation
+
+For solver and optimization examples, check return codes, finite solution values
+and objectives, and constraint residuals against the stated bounds. A successful
+Documenter build establishes execution, not numerical correctness. Keep warnings
+and failures visible; do not suppress them or relax constraints to pass a build.

--- a/docs/src/scenarios/scenario2.md
+++ b/docs/src/scenarios/scenario2.md
@@ -11,7 +11,8 @@ Random.seed!(12345)
 Dₜ = Differential(t)
 @variables S(t)=0.97 E(t)=0.02 I(t)=0.01 R(t)=0.0 H(t)=0.0 D(t)=0.0
 @variables T(t) η(t) cumulative_I(t)=0.0
-@parameters β₁=0.06 β₂=0.015 β₃=0.005 α=0.003 γ₁=0.007 γ₂=0.001 δ=0.2 μ=0.04
+@discretes β₁(t)=0.06 β₂(t)=0.015 β₃(t)=0.005
+@parameters α=0.003 γ₁=0.007 γ₂=0.001 δ=0.2 μ=0.04
 eqs = [T ~ S + E + I + R + H + D
        η ~ (β₁ * E + β₂ * I + β₃ * H)
        Dₜ(S) ~ -η * S
@@ -86,8 +87,8 @@ end
 function g(res, ts, p = nothing)
     tstart = ts[1]
     tstop = ts[2]
-    start_intervention = (t == tstart) => [β₁ ~ β₁ / 2, β₂ ~ β₂ / 2, β₃ ~ β₃ / 2]
-    stop_intervention = (t == tstop) => [β₁ ~ β₁ * 2, β₂ ~ β₂ * 2, β₃ ~ β₃ * 2]
+    start_intervention = (t == tstart) => [β₁ => β₁ / 2, β₂ => β₂ / 2, β₃ => β₃ / 2]
+    stop_intervention = (t == tstop) => [β₁ => β₁ * 2, β₂ => β₂ * 2, β₃ => β₃ * 2]
     @named opttime_sys = ODESystem(eqs, t;
         discrete_events = [
             start_intervention,
@@ -139,9 +140,9 @@ function g(res, reduction_rate, p = nothing)
     reduction_rate = reduction_rate[1]
     root_eqs = [H ~ 0.05 * 0.8]
     affect = [
-        β₁ ~ β₁ * (1 - reduction_rate),
-        β₂ ~ β₂ * (1 - reduction_rate),
-        β₃ ~ β₃ * (1 - reduction_rate)
+        β₁ => β₁ * (1 - reduction_rate),
+        β₂ => β₂ * (1 - reduction_rate),
+        β₃ => β₃ * (1 - reduction_rate)
     ]
     @named mask_system = ODESystem(eqs, t; continuous_events = root_eqs => affect)
     mask_system = structural_simplify(mask_system)


### PR DESCRIPTION
## Change

Migrate scenario2's three event-updated β values to `@discretes` and replace equation-form event affects with Pair updates. Event times, update values, original unknowns, thresholds, and optimizer budgets are unchanged. Add concise docs guidance to check numerical validity as well as execution.

This branch includes the separate scenario2 observable-defaults prerequisite commit; only the final commit is the event migration.

## Failing before / passing after

The runner evaluates the actual nine named scenario2 documentation blocks:
```console
$ julia --startup-file=no --project=docs ../EasyModelAnalysis-intervention-audit/.validation/run-scenario2.jl <page-before-event-fix>
ERROR: LoadError: The equations of a system must involve the unknowns/observables. The following equations were found to have no unknowns/observables:
[block 6; three β equations; exit 1]

$ julia --startup-file=no --project=docs ../EasyModelAnalysis-intervention-audit/.validation/run-scenario2.jl docs/src/scenarios/scenario2.md
PASS scenario2 block 9
[all nine blocks executed; exit 0]
```

Separate analytical checks: old discrete API failed; migrated discrete API 4/4, continuous control 3/3 passed. Local QA 23/23; Core 31/31, exit 0. Scoped formatting, spelling, and diff checks passed.

**Execution is not numerical success:** the unchanged timed optimizer returned MaxTime, objective Inf, u=[45,45], and maximum hospitalization 0.0527007069 > 0.05. The separate parameterized-times follow-up addresses that failure. This PR alone must not be described as fixing the optimization.

**Full strict docs did not pass:** exit 124 at six hours, with 46 failed blocks elsewhere and no final completion summary.

## Validation scope

Historical results below were run locally with Julia 1.11.9 before rebasing onto current main (which now includes https://github.com/SciML/EasyModelAnalysis.jl/pull/336 and https://github.com/SciML/EasyModelAnalysis.jl/pull/337). The changed page is preserved by the rebase. These are not claims that the full documentation or all downstream packages pass. The user requested draft publication with these outstanding gates disclosed.

Native test/build commands, with a workspace-local TMPDIR and headless plotting:
```sh
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GKSwstype=100 timeout 21600 julia --startup-file=no --project=docs docs/make.jl
```
GPU paths, downstream packages, and deployment were not verified. No tests or documentation errors were disabled.

Please ignore this draft until reviewed by @ChrisRackauckas.
 
The post-rebase page is byte-identical to its locally validated pre-rebase version. Fresh post-rebase QA and focused page checks were launched on September 12 and remain pending at publication; they are not counted as passes. Post-rebase spelling and diff checks passed.

Prerequisite draft: https://github.com/SciML/EasyModelAnalysis.jl/pull/342

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
