### PR TITLE
Parameterize scenario2 intervention times

### DIFF
--- a/docs/src/scenarios/scenario2.md
+++ b/docs/src/scenarios/scenario2.md
@@ -84,19 +84,25 @@ function f(ts, p = nothing)
     tstop - tstart
 end
 
+@parameters intervention_start = 0.0 intervention_stop = 90.0
+start_intervention = (t == intervention_start) => [β₁ => β₁ / 2, β₂ => β₂ / 2, β₃ => β₃ / 2]
+stop_intervention = (t == intervention_stop) => [β₁ => β₁ * 2, β₂ => β₂ * 2, β₃ => β₃ * 2]
+@named opttime_sys = ODESystem(
+    eqs, t, [S, E, I, cumulative_I, R, H, D, T, η],
+    [p; intervention_start; intervention_stop];
+    discrete_events = [start_intervention, stop_intervention]
+)
+opttime_sys = structural_simplify(opttime_sys)
+opttime_prob = ODEProblem(opttime_sys, [], [0.0, 90.0])
+opttime_prob = remake(opttime_prob; u0 = u60)
+
 function g(res, ts, p = nothing)
     tstart = ts[1]
     tstop = ts[2]
-    start_intervention = (t == tstart) => [β₁ => β₁ / 2, β₂ => β₂ / 2, β₃ => β₃ / 2]
-    stop_intervention = (t == tstop) => [β₁ => β₁ * 2, β₂ => β₂ * 2, β₃ => β₃ * 2]
-    @named opttime_sys = ODESystem(eqs, t;
-        discrete_events = [
-            start_intervention,
-            stop_intervention
-        ])
-    opttime_sys = structural_simplify(opttime_sys)
-    prob = ODEProblem(opttime_sys, [], [0.0, 90.0])
-    prob = remake(prob; u0 = u60)
+    prob = remake(
+        opttime_prob;
+        p = [intervention_start => tstart, intervention_stop => tstop]
+    )
     sol = solve(prob, saveat = 0.0:1.0:90.0, tstops = [tstart, tstop])
     hospitalizations = vec(sol(0.0:1.0:90.0, idxs = H))
     if SciMLBase.successful_retcode(sol.retcode)
@@ -115,12 +121,16 @@ min_intervention_timespan = solve(optprob,
     OptimizationMOI.MOI.OptimizerWithAttributes(NLopt.Optimizer,
         "algorithm" => :GN_ORIG_DIRECT,
         "maxtime" => 60.0))
+@assert isfinite(min_intervention_timespan.objective)
 min_intervention_timespan.u
 ```
 
 ```@example scenario2
 res = zeros(92)
 g(res, min_intervention_timespan.u)
+@assert all(isfinite, res)
+@assert maximum(res[1:91]) <= 0.05
+@assert res[92] >= 0.0
 maximum(res[1:91])
 ```
 


### PR DESCRIPTION
## Change

Make the intervention start/stop symbolic parameters, construct the intervention system and problem once, and remake only parameter values for each objective evaluation. Preserve the original unknown order, event updates, explicit tstops, 60-second optimization budget, GN_ORIG_DIRECT, start point, daily 92 constraints, and thresholds. Add executable assertions for finite objective/constraints and the stated bounds.

This branch includes the separate scenario2 observable-defaults and event-API prerequisite commits; only the final commit parameterizes time. No warmup, reduced sample count, relaxed bound, or increased budget is used.

## Failing before / passing after

The same official finite-objective assertion was added to the before control:
```console
$ julia --startup-file=no --project=docs ../EasyModelAnalysis-intervention-audit/.validation/run-scenario2.jl <unparameterized-page-with-assertions>
ERROR: LoadError: AssertionError: isfinite(min_intervention_timespan.objective)
[block 6; exit 1]

$ julia --startup-file=no --project=docs ../EasyModelAnalysis-intervention-audit/.validation/run-scenario2.jl docs/src/scenarios/scenario2.md
CONSTRAINTS block=7 finite=true maximum=28.434119058685095
CONSTRAINTS block=9 finite=true maximum=0.049495697070600975
PASS scenario2 block 9
[all nine blocks; exit 0]
```

Fresh-process timed result: Success, u=[1.625577125839622,30.059696184524718], objective 28.434119058685095, maximum hospitalization 0.04999999963203557; bound residual -3.6796442975939314e-10. The unchanged continuous section returned MaxTime with finite feasible sampled constraints, not an optimality certificate.

Equivalence regression: 25/25 checks passed across eight predefined time pairs; all 92 sampled constraint values were bitwise equal to the old implementation. Re-evaluation at the optimized point also passed 5/5 checks. These checks establish sampled feasibility, not continuous-time feasibility or global optimality.

Local native QA 23/23 (10m13.7s); Core 31/31, exit 0. Scoped Runic checks of three new fragments, spelling, and diff checks passed. **Full strict docs did not pass:** exit 124 at six hours, with other documentation failures.

## Validation scope

Historical results below were run locally with Julia 1.11.9 before rebasing onto current main (which now includes https://github.com/SciML/EasyModelAnalysis.jl/pull/336 and https://github.com/SciML/EasyModelAnalysis.jl/pull/337). The changed page is preserved by the rebase. These are not claims that the full documentation or all downstream packages pass. The user requested draft publication with these outstanding gates disclosed.

Native test/build commands, with a workspace-local TMPDIR and headless plotting:
```sh
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GKSwstype=100 timeout 21600 julia --startup-file=no --project=docs docs/make.jl
```
GPU paths, downstream packages, and deployment were not verified. No tests or documentation errors were disabled.

Please ignore this draft until reviewed by @ChrisRackauckas.
 
The post-rebase page is byte-identical to its locally validated pre-rebase version. Fresh post-rebase QA and focused page checks were launched on September 12 and remain pending at publication; they are not counted as passes. Post-rebase spelling and diff checks passed.

Prerequisite drafts, in order: https://github.com/SciML/EasyModelAnalysis.jl/pull/342, https://github.com/SciML/EasyModelAnalysis.jl/pull/343

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
