### PR TITLE
Refresh Carcione SBML system construction and solver

### DIFF
--- a/docs/src/examples/Carcione2020.md
+++ b/docs/src/examples/Carcione2020.md
@@ -13,7 +13,7 @@ mdl = readSBML(xmlfile, doc -> begin
 end)
 
 rs = ReactionSystem(mdl)  # If you want to create a reaction system
-odesys = convert(ODESystem, rs)  # Alternatively: ODESystem(mdl)
+odesys = ODESystem(mdl)
 ```
 
 ```@example carcione
@@ -25,7 +25,7 @@ sys = structural_simplify(odesys)
 @unpack alpha, epsilon, gamma, mu, beta, City = sys
 tspan = (0.0, 1.0)
 prob = ODEProblem(sys, [], tspan, [])
-sol = solve(prob, Rodas5())
+sol = solve(prob, Rodas5P())
 plot(sol, idxs = Deceased)
 ```
 


### PR DESCRIPTION
## Change

Use SBMLToolkit's direct `ODESystem(mdl)` construction and the current `Rodas5P()` solver in the Carcione tutorial. Keep structural_simplify, model input, parameters, time span, and the full 2,000-sample sensitivity example unchanged. No dependency is added.

## Failing before / passing after — partial migration only

The original conversion-based page fails during the initial construction blocks in the strict docs build. The registered-dependency control evaluates the first three actual corrected documentation blocks, then checks successful return code, completion time, and finite values:

Before, from the unmodified example in the strict build:

```console
$ GKSwstype=100 timeout 21600 julia --startup-file=no --project=docs docs/make.jl
failed to run `@example` block in docs/src/examples/Carcione2020.md:3-17
MethodError: Cannot `convert` an object of type Catalyst.ReactionSystem{...} to an object of type ModelingToolkitBase.IntermediateDeprecationSystem
[type arguments abbreviated; full build later timed out]
```

After:
```console
$ julia --startup-file=no --project=EasyModelAnalysis-ensemble-current/docs .validation/carcione-registered/initial.jl
INITIAL retcode=Success final_time=1.0
Registered Carcione initial solve | 3  3
[initial-solve assertions passed]
```

**The complete regression still fails (exit 1).** The next parameter-override sensitivity check fails before solve because `Total_population#0(t)` is present but is not an unknown. This draft does not claim a fully repaired tutorial or a passing 2,000-sample registered-dependency sensitivity run. Related ownership investigation: https://github.com/SciML/ModelingToolkit.jl/pull/5073.

The passing initial solve used registered SBMLToolkit 0.1.42, ModelingToolkit 11.42, ModelingToolkitBase 1.69, and SymbolicUtils 4.46.1, with only EasyModelAnalysis developed locally. An older composed run with local dependency patches is not used as evidence of registered-dependency success.

Full strict documentation is not green (six-hour timeout and example failures). No dedicated Carcione native QA/Core success is claimed; these two lines change only the documentation example. Formatting/spelling/diff checks and the executable initial-solve checks cover this limited migration. The residual failing sensitivity regression is retained, not suppressed.

## Validation scope

Historical results below were run locally with Julia 1.11.9 before rebasing onto current main (which now includes https://github.com/SciML/EasyModelAnalysis.jl/pull/336 and https://github.com/SciML/EasyModelAnalysis.jl/pull/337). The changed page is preserved by the rebase. These are not claims that the full documentation or all downstream packages pass. The user requested draft publication with these outstanding gates disclosed.

Native test/build commands, with a workspace-local TMPDIR and headless plotting:
```sh
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
GKSwstype=100 timeout 21600 julia --startup-file=no --project=docs docs/make.jl
```
GPU paths, downstream packages, and deployment were not verified. No tests or documentation errors were disabled.

Please ignore this draft until reviewed by @ChrisRackauckas.
 
The post-rebase page is byte-identical to its locally validated pre-rebase version. Fresh post-rebase QA and focused page checks were launched on September 12 and remain pending at publication; they are not counted as passes. Post-rebase spelling and diff checks passed.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
